### PR TITLE
fix init project exception on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Some differences have been documented, see [Differences with Clojure](doc/differ
 
 # Quick starts
 
+> The minimum JDK version is 11
+
 - [Plain Dart](doc/quick-start.md) (recommended first step)
 - [With Flutter](doc/flutter-quick-start.md)
 


### PR DESCRIPTION
On Windows, the default environment variable is Path instead of PATH, so the execute function has a null pointer problem here.

In addition, the bin directory in the sdk distributed by flutter contains two programs, dart and dart.bat, in which the execute function will incorrectly find dart (not a valid Win32 program under Windows).