### PR TITLE
fix widget-macro's key creation

### DIFF
--- a/clj/src/cljd/flutter/alpha.cljd
+++ b/clj/src/cljd/flutter/alpha.cljd
@@ -29,14 +29,14 @@
     (if watch
       (cond->>
         `(widgets/StatefulBuilder.
-           :key ~(cond-> key (contains? opts :key) (list `foundation/ValueKey.))
+           :key ~(cond->> key (contains? opts :key) (list `foundation/ValueKey.))
            :builder (fn [~flutter-build-ctx set-state#]
                       (add-watch ~watch ~flutter-build-ctx (fn [k# r# o# n#] (set-state# (fn []))))
                       ~expr))
         state
         (list `let [(first state) `(atom ~(second state))]))
       `(widgets/Builder.
-         :key ~(cond-> key (contains? opts :key) (list `foundation/ValueKey.))
+         :key ~(cond->> key (contains? opts :key) (list `foundation/ValueKey.))
          :builder (fn [~flutter-build-ctx] ~expr)))))
 
 #_(defmacro with-ctx [ctx & body]


### PR DESCRIPTION
The order in the generated macro is incorrect: 

```clojure
(widgets/Builder.
 :key
 ("key-name" foundation/ValueKey.)
 :builder
 ....
```

from:
```clojure
(macroexpand 
  '(widget
     :context ctx
     :key "key-name" ....
```

Quick demo: 
<img width="482" alt="image" src="https://user-images.githubusercontent.com/14236531/164081472-4cf52a66-b2c1-4365-9b12-4259f3f2be08.png">
