### PR TITLE
omit Non-arg vec return type hint linter

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
@@ -1,1 +1,2 @@
-{:hooks {:analyze-call {cljd.flutter.alpha/widget hooks.flutter/widget}}}
+{:linters {:non-arg-vec-return-type-hint {:level :off}} 
+ :hooks {:analyze-call {cljd.flutter.alpha/widget hooks.flutter/widget}}}


### PR DESCRIPTION
until it will be fix https://github.com/Tensegritics/ClojureDart/issues/27 <p>

discussed in [slack](https://clojurians.slack.com/archives/C03A6GE8D32/p1650367945037689)