### PR TITLE
update clj-kondo widget hook (:with :ticker)

### DIFF
--- a/clj/src/cljd/flutter/alpha.cljd
+++ b/clj/src/cljd/flutter/alpha.cljd
@@ -39,7 +39,7 @@
                                         :dispose nil
                                         binding)))
                             (partition 2 with))
-        dispose-statements (second (reduce ; we lsoe inferred types
+        dispose-statements (second (reduce ; we lose inferred types
                                      (fn [[dispose stmts] [lhs rhs]]
                                        (case lhs
                                          :let [nil stmts]


### PR DESCRIPTION
- use :ticker name and :tickers names as let bindings
- use :with and :with->:let names as let bindings
- :with allowed only with state
- :ticker allowed only with state
- :tickers allowed only with state
- can't use both :ticker and :tickers
- :with top names should be simple bindings
- :with let could be not simple - allow destructuring

where state = (or state watch)

[Slack thread](https://clojurians.slack.com/archives/C03A6GE8D32/p1650715334226749?thread_ts=1650669838.842329&cid=C03A6GE8D32)