### PR TITLE
Fix doc typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ In the [samples directory](samples/) you'll find some ports of [Flutter recipes]
 Clone the ClojureDart repo.
 
 ```shell
-git clone https://github.com/Tensegritics/ClojureDart.git`
+git clone https://github.com/Tensegritics/ClojureDart.git
 ```
 
 Go to the sample you want to try, let's say `fab`:

--- a/doc/MUNGING.md
+++ b/doc/MUNGING.md
@@ -43,7 +43,7 @@ In some contexts, suffixes may be appended to the munged name of a symbol. A suf
 
 `$iproto` is for the class implementing the IProtocol for a given protocol.
 
-`$cext` is for a a class implementing a class extension.
+`$cext` is for a class implementing a class extension.
 
 `$extension` is for the actual singleton of a `$cext`.
 

--- a/doc/differences.md
+++ b/doc/differences.md
@@ -114,7 +114,7 @@ However when you want to access a static member **in Clojure** you would write `
 ### reify/deftype
 #### `^:abstract`
 **`deftype`**
-A type name can have the `:abstract` metadata to indicate the generated class to be asbtract.
+A type name can have the `:abstract` metadata to indicate the generated class to be abstract.
 
 #### `:extends`
 **`reify` and `deftype`**
@@ -132,8 +132,7 @@ The `:type-only` option instructs `deftype` to not create factory function (`->M
 
 #### `^:mixin`
 **`reify`, `defrecord` and `deftype`**
-This metadata on implemented classes specify these classes should be considered [mixins](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mix
-ins) and not [interfaces](https://dart.dev/guides/language/language-tour#implicit-interfaces).
+This metadata on implemented classes specify these classes should be considered [mixins](https://dart.dev/guides/language/language-tour#adding-features-to-a-class-mixins) and not [interfaces](https://dart.dev/guides/language/language-tour#implicit-interfaces).
 
 #### `^:getter`/`^:setter`
 **`reify`, `defrecord` and `deftype`**
@@ -142,7 +141,7 @@ Method names can be tagged with `:getter` and/or `:setter` if the method is in f
 For a getter you must provide a 1-arg arity of the method (`[this]`) and for a setter a 2-arg arity (`[this new-value]`).
 
 #### Calling `super`
-When you must call the `super` implementation (since one can now extends a super type) you have to add metadata on the "this" parameter of a method. For example when implementing a [State](https://api.flutter.dev/flutter/widgets/State/initState.html) one can write:
+When you must call the `super` implementation (since one can now extend a super type) you have to add metadata on the "this" parameter of a method. For example when implementing a [State](https://api.flutter.dev/flutter/widgets/State/initState.html) one can write:
 
 ```clj
 (initState [^{:super papa} self]
@@ -166,7 +165,7 @@ Dart methods may take named parameters, to call them in ClojureDart just use a k
 ```
 
 ### Generics
-Unlike Java, Dart generics are not erased -- it means that on the JVM at runtime a `List<String>` is just a `List` but that in Dart at runtime it's still a `List<String>`. This creates two problems: expressing parametrized types and dealing with the mismatch between string typing of collections items and Clojure's collections.
+Unlike Java, Dart generics are not erased — it means that on the JVM at runtime a `List<String>` is just a `List` but that in Dart at runtime it's still a `List<String>`. This creates two problems: expressing parametrized types and dealing with the mismatch between strong typing of collections items and Clojure's collections.
 
 #### Parametrized types
 
@@ -182,7 +181,7 @@ Two vectors containing the same items but with different type parameters are sti
 
 When a `List` of a given type is expected the [`cast`](https://api.dart.dev/stable/2.9.3/dart-core/List/cast.html) method can be used to get a vector of the expected type. It's really a lightweight operation as only the root object is changed.
 
-Furthermore, ClojureDart will automatically emits such `cast` calls. This means that in practice you can pass a Clojure vector (or a set or a map) where a typed List (resp. a Set or a Map) is expected and it will just work — as long as the items are of the right type, or at least those that will be looked up.
+Furthermore, ClojureDart will automatically emit such `cast` calls. This means that in practice you can pass a Clojure vector (or a set or a map) where a typed List (resp. a Set or a Map) is expected and it will just work — as long as the items are of the right type, or at least those that will be looked up.
 
 
 ### Dart literals

--- a/doc/flutter-helpers.md
+++ b/doc/flutter-helpers.md
@@ -124,7 +124,7 @@ By default a resource is disposed by calling its `.dispose` method. However if t
 
 The resource name is threaded (as per `->`) through the `:dispose` form. Most of the time it will be simply a method or a function.
 
-Last, you can introduce intermediate values to use in resource initialization via `:let`:
+Lastly, you can introduce intermediate values to use in resource initialization via `:let`:
 
 ```clj
 :with [res1 init1

--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -74,7 +74,7 @@ Compiled Dart files are found under `lib/cljd-out`; to execute the program, just
 dart run
 ```
 
-By doing so you have ran your program on the Dart VM. To get an actual executable, enter:
+By doing so you have run your program on the Dart VM. To get an actual executable, enter:
 
 ``` shell
 dart compile exe -o helloworld bin/helloworld.dart


### PR DESCRIPTION
Fixing a few typos I've noticed while reading the docs. Not sure if `string typing` (instead of `strong typing`) was intentional - it can work both ways. I'll revert that bit from the PR if it was.