### PR TITLE
Add semicolons to M cli examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ cd ClojureDart/samples/fab
 
 Init the project:
 ```shell
-clj -Mcljd init
+clj -M:cljd init
 ```
 
 Start a simulator or connect a device.
 
 Then launch the watcher:
 ```shell
-clj -Mcljd flutter
+clj -M:cljd flutter
 ```
 
 Enjoy! 🧃

--- a/doc/flutter-quick-start.md
+++ b/doc/flutter-quick-start.md
@@ -58,7 +58,7 @@ EOF
 ## 4. Initialize the project
 
 ``` shell
-clj -Mcljd init
+clj -M:cljd init
 ```
 
 ## 5. Create a ClojureDart file with a main entry-point
@@ -121,7 +121,7 @@ Please follow [those guidelines](https://docs.genymotion.com/desktop/Get_started
 ## 8. Start the ClojureDart watcher
 
 ``` shell
-clj -Mcljd flutter
+clj -M:cljd flutter
 ```
 
 ## 9. Enjoy!


### PR DESCRIPTION
Skipping the colon is not supported in Clojure's cli

Conversation in [slack](https://clojurians.slack.com/archives/C6QH853H8/p1655410531905709)