### PR TITLE
seq? bug with nil

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -902,7 +902,7 @@
 (defn ^bool seq?
   {:inline (fn [x] `(satisfies? ISeq ~x))
    :inline-arities #{1}}
-  [x] (satisfies? ISeq x))
+  [x] (and (not (nil? x)) (satisfies? ISeq x)))
 
 (extend-type Null
   ISeqable


### PR DESCRIPTION
Found this by using `(walk/stringify-keys)`: `(seq? nil)` was true.