### PR TITLE
test-metadata now pass.

### DIFF
--- a/clj/test/cljd/test_clojure/core_test.cljd
+++ b/clj/test/cljd/test_clojure/core_test.cljd
@@ -15,7 +15,7 @@
   (:require [cljd.string :as s])
   (:use [cljd.test :only [deftest is testing are]]))
 
-#_(deftest test-metadata
+(deftest test-metadata
   (testing "Testing metadata"
     (is (= {"x" "y"} (meta ^{"x" "y"} [])))))
 


### PR DESCRIPTION
[9996903](https://github.com/Tensegritics/ClojureDart/commit/99969035c5dc892774d7512e264704bc3c6b27f3) also fixed this tests. 