### PR TITLE
add arity for IFn 

### DIFF
--- a/clj/src/cljd/compiler.cljc
+++ b/clj/src/cljd/compiler.cljc
@@ -1412,7 +1412,7 @@
          bindings (cond-> bindings must-lift butlast)]
      [bindings dart-args])))
 
-(def ^:dynamic *threshold* 10)
+(def ^:dynamic *threshold* 19)
 
 (defn emit-fn-call [[f & args] env]
   ;; TO BE CONTINUED

--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -431,8 +431,19 @@
     [this a b c d e f]
     [this a b c d e f g]
     [this a b c d e f g h]
-    [this a b c d e f g h i])
-  (-invoke-more [this a b c d e f g h i rest])
+    [this a b c d e f g h i]
+    [this a b c d e f g h i j]
+    [this a b c d e f g h i j k]
+    [this a b c d e f g h i j k l]
+    [this a b c d e f g h i j k l m]
+    [this a b c d e f g h i j k l m n]
+    [this a b c d e f g h i j k l m n o]
+    [this a b c d e f g h i j k l m n o p]
+    [this a b c d e f g h i j k l m n o p q]
+    [this a b c d e f g h i j k l m n o p q r]
+    [this a b c d e f g h i j k l m n o p q r s]
+    [this a b c d e f g h i j k l m n o p q r s t])
+  (-invoke-more [this a b c d e f g h i j k l m n o p q r s t more])
   (-apply [this more]))
 
 (defn ^bool ifn?

--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -441,9 +441,9 @@
     [this a b c d e f g h i j k l m n o p]
     [this a b c d e f g h i j k l m n o p q]
     [this a b c d e f g h i j k l m n o p q r]
-    [this a b c d e f g h i j k l m n o p q r s]
-    [this a b c d e f g h i j k l m n o p q r s t])
-  (-invoke-more [this a b c d e f g h i j k l m n o p q r s t more])
+    #_[this a b c d e f g h i j k l m n o p q r s]
+    #_[this a b c d e f g h i j k l m n o p q r s t])
+  (-invoke-more [this a b c d e f g h i j k l m n o p q r #_#_s t more])
   (-apply [this more]))
 
 (defn ^bool ifn?


### PR DESCRIPTION
PR for #65 

IFn in ClojureScript has fn of (arity 0, arity 1, ... arity 20, arity 21). 
and last alphabet argument is (nil, `a`, ... `t`, `more`) 

```
(defprotocol IFn
  "Protocol for adding the ability to invoke an object as a function.
  For example, a vector can also be used to look up a value:
  ([1 2 3 4] 1) => 2"
  (-invoke
    [this]
    [this a]
    [this a b]
    [this a b c]
    [this a b c d]
    [this a b c d e]
    [this a b c d e f]
    [this a b c d e f g]
    [this a b c d e f g h]
    [this a b c d e f g h i]
    [this a b c d e f g h i j]
    [this a b c d e f g h i j k]
    [this a b c d e f g h i j k l]
    [this a b c d e f g h i j k l m]
    [this a b c d e f g h i j k l m n]
    [this a b c d e f g h i j k l m n o]
    [this a b c d e f g h i j k l m n o p]
    [this a b c d e f g h i j k l m n o p q]
    [this a b c d e f g h i j k l m n o p q r]
    [this a b c d e f g h i j k l m n o p q r s]
    [this a b c d e f g h i j k l m n o p q r s t]
    [this a b c d e f g h i j k l m n o p q r s t rest]))
```

before this change 

IFn in ClojureDart has fn of (arity 0, arity 1, ... arity 10). 
and last alphabet argument is (nil, `a`, ... `i`) 

And I tried to add method to match `IFn of ClojureScript` by adding until `t`.
But If I add args and do `./run-tests`, `Execution error` raised. 

> Execution error at cljd.compiler/do-def$fn (compiler.cljc:2239).
> Can't specify more than 20 params

So I reduced count of args until no error raised. 





