### PR TITLE
Throw an error when Java is not recent enough to run ClojureDart.

### DIFF
--- a/clj/src/cljd/compiler.cljc
+++ b/clj/src/cljd/compiler.cljc
@@ -12,6 +12,13 @@
             [clojure.java.io :as io]
             [clojure.edn :as edn]))
 
+(let [java-major-version (->> (System/getProperty "java.version")
+                              (re-seq #"\d+")
+                              first
+                              (Integer/parseInt))]
+  (when (< java-major-version 11)
+    (throw (ex-info "ClojureDart requires Java 11 or above." {}))))
+
 (def dc-void {:kind :class
               :element-name        "void"
               :canon-qname 'void


### PR DESCRIPTION
Not sure if this is the best approach for it, but it would be nice to have a specific error when the Java version is to old to run ClojureDart. 