### PR TITLE
Fix `use-fixtures :each` behavior

### DIFF
--- a/clj/src/cljd/test.cljd
+++ b/clj/src/cljd/test.cljd
@@ -424,6 +424,8 @@
     `(defn ~'^:dart/test main []
        ~(when (the-ns 'cljd-test-once-fixtures)
           `(register-once-fixtures ~'cljd-test-once-fixtures))
+       ~(when (the-ns 'cljd-test-each-fixtures)
+          `(register-each-fixtures ~'cljd-test-each-fixtures))
        ~@tests)))
 
 (defmacro deftest
@@ -443,11 +445,7 @@
     `(do
        (defn ~(vary-meta name assoc ::test true) []
          (let [name# ~(str (:current-ns (:nses &env)) "/" name)
-               thunk#
-               (fn []
-                 ~(when (the-ns 'cljd-test-each-fixtures)
-                    `(register-each-fixtures ~'cljd-test-each-fixtures))
-                 (testing name# ~@body))]
+               thunk# (fn [] (testing name# ~@body))]
            (if *in-test*
              (thunk#)
              (binding [*in-test* true]

--- a/clj/src/cljd/test.cljd
+++ b/clj/src/cljd/test.cljd
@@ -135,6 +135,7 @@
       Return value will be passed as argument to the 1-arg arity.
       Thus you can pass references to resources to free etc.)
     ([resources]
+     The resources passed in are what the zero-arity \"setup\" returned
      Tear-down / clean-up code here)
 
    Fixtures are attached to namespaces in one of two ways.  \"each\"

--- a/clj/src/cljd/test.cljd
+++ b/clj/src/cljd/test.cljd
@@ -148,7 +148,7 @@
    (use-fixtures :each fixture1 fixture2 ...)
    The fixture1, fixture2 are just functions like the example above.
    They can also be anonymous functions, like this:
-   (use-fixtures :each (fn [f] setup... (f) cleanup...))
+   (use-fixtures :each (fn ([] setup...) ([res] cleanup...)))
 
    The other kind of fixture, a \"once\" fixture, is only run once,
    around ALL the tests in the namespace.  \"once\" fixtures are useful

--- a/clj/src/cljd/test.cljd
+++ b/clj/src/cljd/test.cljd
@@ -395,10 +395,18 @@
   (let [v (volatile! nil)]
     [#(vreset! v (f)) #(f @v)]))
 
-(defn register-fixtures [fixtures-callbacks]
+(defn register-once-fixtures [fixtures-callbacks]
   (doseq [[setUp tearDown] fixtures-callbacks]
     (dt/setUpAll setUp)
     (dt/tearDownAll tearDown)))
+
+(defn register-each-fixtures [fixtures-callbacks]
+  (doseq [[setUp tearDown] fixtures-callbacks]
+    (dt/setUp setUp)
+    (dt/tearDown tearDown)))
+
+(defn register-fixtures [fixtures-callbacks]
+  (register-once-fixtures fixtures-callbacks))
 
 (defmacro use-fixtures [type & fns]
   `(do
@@ -415,7 +423,7 @@
         tests (keep (fn [[k v]] (when (and (symbol? k) (::test (:meta v))) (list k))) the-ns)]
     `(defn ~'^:dart/test main []
        ~(when (the-ns 'cljd-test-once-fixtures)
-          `(register-fixtures ~'cljd-test-once-fixtures))
+          `(register-once-fixtures ~'cljd-test-once-fixtures))
        ~@tests)))
 
 (defmacro deftest
@@ -438,7 +446,7 @@
                thunk#
                (fn []
                  ~(when (the-ns 'cljd-test-each-fixtures)
-                    `(register-fixtures ~'cljd-test-each-fixtures))
+                    `(register-each-fixtures ~'cljd-test-each-fixtures))
                  (testing name# ~@body))]
            (if *in-test*
              (thunk#)

--- a/clj/test/cljd/test_clojure/test_test.cljd
+++ b/clj/test/cljd/test_clojure/test_test.cljd
@@ -1,0 +1,41 @@
+(ns cljd.test-clojure.test-test
+  (:use [cljd.test :only [deftest testing is use-fixtures]]))
+
+(def- test-state
+  (atom {}))
+
+(defn- onetime-fixture
+  ([] ;; setup
+   (swap! test-state assoc :base-data :foo))
+  ([_] ;; teardown
+   (reset! test-state {})))
+
+(defn- repeated-fixture
+  "Resets test-state to what it was before running the tests `f`"
+  [f]
+  (let [start-state @test-state
+        test-result (f)]
+    (reset! test-state start-state)
+    test-result))
+
+(use-fixtures :once onetime-fixture)
+(use-fixtures :each repeated-fixture)
+
+(deftest mutator-test
+  (testing "Initial state"
+    (is (= {:base-data :foo} @test-state)))
+
+  (testing "Mutating state"
+    (swap! test-state assoc :base-data :bar)
+    (is (= :bar (:base-data @test-state)))
+
+    (swap! test-state assoc :my-data :baz)
+    (is (= :baz (:my-data @test-state))))
+
+  (testing "Mutated state"
+    (is (= :baz (:my-data @test-state))
+        ":each fixtures are run around `deftest`, not individual `is` or `testing`")))
+
+(deftest control-test
+  (testing "Initial state"
+    (is (= {:base-data :foo} @test-state))))

--- a/clj/test/cljd/test_clojure/test_test.cljd
+++ b/clj/test/cljd/test_clojure/test_test.cljd
@@ -1,29 +1,30 @@
 (ns cljd.test-clojure.test-test
   (:use [cljd.test :only [deftest testing is use-fixtures]]))
 
-(def- test-state
+(def ^:private test-state
   (atom {}))
 
-(defn- onetime-fixture
+(defn ^:private onetime-fixture
   ([] ;; setup
    (swap! test-state assoc :base-data :foo))
+  ;; the "teardown" (1-arity) version is called with what the "setup" returned
   ([_] ;; teardown
    (reset! test-state {})))
 
-(defn- repeated-fixture
+(defn ^:private repeated-fixture
   "Resets test-state to what it was before running the tests `f`"
-  [f]
-  (let [start-state @test-state
-        test-result (f)]
-    (reset! test-state start-state)
-    test-result))
+  ([] ;;setup
+   @test-state)
+  ([start-state] ;; teardown
+   (reset! test-state start-state)))
 
 (use-fixtures :once onetime-fixture)
 (use-fixtures :each repeated-fixture)
 
 (deftest mutator-test
   (testing "Initial state"
-    (is (= {:base-data :foo} @test-state)))
+    (is (= {:base-data :foo} @test-state)
+        ":once fixtures are run before any tests and in the very end"))
 
   (testing "Mutating state"
     (swap! test-state assoc :base-data :bar)

--- a/clj/test/cljd/test_clojure/test_test.cljd
+++ b/clj/test/cljd/test_clojure/test_test.cljd
@@ -21,19 +21,17 @@
 (use-fixtures :once onetime-fixture)
 (use-fixtures :each repeated-fixture)
 
-;; test order is not guaranteed, so both tests test both for mutation
-;; and the reset of the state by the :each fixture
+;; test order is not guaranteed, so both tests test for
+;; the reset of the state by the :each fixture
 
 (deftest mutator-test-one
   (testing "Initial state"
-    (is (or (= {:base-data :foo} @test-state)
-            (= {:base-data :bar-2} @test-state))
-        ":once fixtures are run before any tests and in the very end.
-         if mutator-test-two ran first the value is expected to be :bar-2"))
+    (is (= {:base-data :foo} @test-state)
+        ":once fixtures are run before any tests and in the very end"))
 
   (testing "Mutating state"
-    (swap! test-state assoc :base-data :bar-1)
-    (is (= :bar-1 (:base-data @test-state)))
+    (swap! test-state assoc :base-data :bar)
+    (is (= :bar (:base-data @test-state)))
 
     (swap! test-state assoc :my-data :baz)
     (is (= :baz (:my-data @test-state))))
@@ -44,14 +42,12 @@
 
 (deftest mutator-test-two
   (testing "Initial state"
-    (is (or (= {:base-data :foo} @test-state)
-            (= {:bar-data :bar-1} @test-state))
-        ":once fixtures are run before any tests and in the very end.
-         if mutator-test-one ran first the value is expected to be :bar-1"))
+    (is (= {:base-data :foo} @test-state)
+        ":once fixtures are run before any tests and in the very end"))
 
   (testing "Mutating state"
-    (swap! test-state assoc :base-data :bar-2)
-    (is (= :bar-2 (:base-data @test-state)))
+    (swap! test-state assoc :base-data :bar)
+    (is (= :bar (:base-data @test-state)))
 
     (swap! test-state assoc :my-data :baz)
     (is (= :baz (:my-data @test-state))))

--- a/clj/test/cljd/test_clojure/test_test.cljd
+++ b/clj/test/cljd/test_clojure/test_test.cljd
@@ -12,7 +12,7 @@
    (reset! test-state {})))
 
 (defn ^:private repeated-fixture
-  "Resets test-state to what it was before running the tests `f`"
+  "Resets test-state to what it was before running the tests"
   ([] ;;setup
    @test-state)
   ([start-state] ;; teardown

--- a/clj/test/cljd/test_clojure/test_test.cljd
+++ b/clj/test/cljd/test_clojure/test_test.cljd
@@ -21,14 +21,19 @@
 (use-fixtures :once onetime-fixture)
 (use-fixtures :each repeated-fixture)
 
-(deftest mutator-test
+;; test order is not guaranteed, so both tests test both for mutation
+;; and the reset of the state by the :each fixture
+
+(deftest mutator-test-one
   (testing "Initial state"
-    (is (= {:base-data :foo} @test-state)
-        ":once fixtures are run before any tests and in the very end"))
+    (is (or (= {:base-data :foo} @test-state)
+            (= {:base-data :bar-2} @test-state))
+        ":once fixtures are run before any tests and in the very end.
+         if mutator-test-two ran first the value is expected to be :bar-2"))
 
   (testing "Mutating state"
-    (swap! test-state assoc :base-data :bar)
-    (is (= :bar (:base-data @test-state)))
+    (swap! test-state assoc :base-data :bar-1)
+    (is (= :bar-1 (:base-data @test-state)))
 
     (swap! test-state assoc :my-data :baz)
     (is (= :baz (:my-data @test-state))))
@@ -37,6 +42,20 @@
     (is (= :baz (:my-data @test-state))
         ":each fixtures are run around `deftest`, not individual `is` or `testing`")))
 
-(deftest control-test
+(deftest mutator-test-two
   (testing "Initial state"
-    (is (= {:base-data :foo} @test-state))))
+    (is (or (= {:base-data :foo} @test-state)
+            (= {:bar-data :bar-1} @test-state))
+        ":once fixtures are run before any tests and in the very end.
+         if mutator-test-one ran first the value is expected to be :bar-1"))
+
+  (testing "Mutating state"
+    (swap! test-state assoc :base-data :bar-2)
+    (is (= :bar-2 (:base-data @test-state)))
+
+    (swap! test-state assoc :my-data :baz)
+    (is (= :baz (:my-data @test-state))))
+
+  (testing "Mutated state"
+    (is (= :baz (:my-data @test-state))
+        ":each fixtures are run around `deftest`, not individual `is` or `testing`")))

--- a/run-tests
+++ b/run-tests
@@ -28,7 +28,8 @@ cat > src/cljd/run_tests.cljd <<EOF
     cljd.test-clojure.clojure-zip
     cljd.test-clojure.clojure-walk
     cljd.test-clojure.other-functions
+    cljd.test-clojure.test-test
     cljd.test-reader.reader-test))
 EOF
-clojure -M -m cljd.build compile cljd.test-clojure.core-test-cljd cljd.test-clojure.string cljd.test-clojure.core-test cljd.test-clojure.for cljd.test-clojure.clojure-zip cljd.test-clojure.clojure-walk cljd.test-clojure.other-functions cljd.test-reader.reader-test
+clojure -M -m cljd.build compile cljd.test-clojure.core-test-cljd cljd.test-clojure.string cljd.test-clojure.core-test cljd.test-clojure.for cljd.test-clojure.clojure-zip cljd.test-clojure.clojure-walk cljd.test-clojure.other-functions cljd.test-clojure.test-test cljd.test-reader.reader-test
 dart test -p vm


### PR DESCRIPTION
Fixes #242 

## Changes

### Move :each fixtures to the namespace level

In clojure.test they're at the namespace level so I decided to match to that. In cljd (dart) they could be at the test group level (though I don't know if cljd.test translates `testing`s to dart test `group`s). However they can't be included in the `thunk#` that is given to `dt/test`--this results in a `Can't call setUp() once tests have begun running` error. 

### Add explanation and adjust docstring

It wasn't clear to me at first what "resources" are passed in to the unary fixture, so I added an explanation line to the docstring. I also tweaked a location that referred to the clojure.test way of writing a fixture--in cljd.test they have to be a 0-ary and a unary from what I see. (The clojure.test way `(fn [f] ,,, (f) ,,,)` resulted in a NoSuchMethodError: Closure call with mismatched arguments.)