### PR TITLE
Port add-tap / remove-tap from ClojureScript

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -8167,7 +8167,7 @@
   function of no arguments. Returns true if successful, false otherwise." :dynamic true}
   *exec-tap-fn*
   [f]
-  (dart-async/Timer. (Duration. .milliseconds 0) f)
+  (dart-async/scheduleMicrotask f)
   true)
 
 (defonce ^{:private true}

--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -8162,3 +8162,43 @@
   handled as if by repeated uses of conj."
   ([& keys]
    (apply sorted-set-by compare keys)))
+
+(defn ^{:doc "Arranges to have tap functions executed via the supplied f, a
+  function of no arguments. Returns true if successful, false otherwise." :dynamic true}
+  *exec-tap-fn*
+  [f]
+  (dart-async/Timer. (Duration. .milliseconds 0) f)
+  true)
+
+(defonce ^{:private true}
+  tapset nil)
+
+(defn- maybe-init-tapset []
+  (when (nil? tapset)
+    (set! tapset (atom #{}))))
+
+(defn add-tap
+  "Adds f, a fn of one argument, to the tap set. This function will be called with
+  anything sent via tap>. Remember f in order to remove-tap"
+  [f]
+  (maybe-init-tapset)
+  (swap! tapset conj f)
+  nil)
+
+(defn remove-tap
+  "Remove f from the tap set."
+  [f]
+  (maybe-init-tapset)
+  (swap! tapset disj f)
+  nil)
+
+(defn ^bool tap>
+  "Sends x to any taps. Returns the result of *exec-tap-fn*, a Boolean value."
+  [x]
+  (maybe-init-tapset)
+  (*exec-tap-fn*
+    (fn []
+      (doseq [tap @tapset]
+        (try
+          (tap x)
+          (catch Exception ex))))))


### PR DESCRIPTION
I'm looking at providing some initial support for ClojureDart in [Portal](https://github.com/djblue/portal/pull/193) and people typically use it via `add-tap` / `remove-tap`. I took the ClojureScript implementation and got it working in dart.