### PR TITLE
fix error (dynamic) => dynamic is not a subtype of type 'Widget'

### DIFF
--- a/samples/navigate_named_routes/src/sample/navigate_named_routes.cljd
+++ b/samples/navigate_named_routes/src/sample/navigate_named_routes.cljd
@@ -39,7 +39,7 @@
     .routes       (into {}
                         (keep (fn [[k v]]
                                 {k (fn ^m/Widget k [ctx]
-                                     v)}))
+                                     (v ctx))}))
                         {"/"       first-screen
                          "/second" second-screen}))))
 


### PR DESCRIPTION
caused by returning function v (first-screen,second-screen) instead of the `(v ctx)`. Since routes paramter expects `Map<String, WidgetBuilder>?`, the values of routes map should be functions of `BuildContext` to `Widget`. Instead the previous implementation had functions of `BuildContext` that return functions of `BuildContext` to `Widget`.