### PR TITLE
Add lint support for dynamic and other dart:core types

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
@@ -2,15 +2,20 @@
            :flutter/widget {:level :error}
            :clojure-lsp/unused-public-var {:exclude #{main}}
            :unresolved-namespace {:exclude [dart dart:core]}
-           :unresolved-symbol 
-           {:exclude [AbstractClassInstantiationError ArgumentError AssertionError BidirectionalIterator 
-                      BigIntbool bool CastError Comparable Comparator ConcurrentModificationError 
-                      CyclicInitializationError DateTime double Duration Error Exception Expando  
-                      FallThroughError Finalizer FormatException Function IndexError IntegerDivisionByZeroException
-                      Invocation Iterable Iterator List Map MapEntry Match NoSuchMethodError Null NullThrownError
-                      Object OutOfMemoryError Pattern pragma RangeError RegExp RegExpMatch Runes RuneIterator Set 
-                      Sink StackOverflowError StackTrace StateError Stopwatch String StringBuffer StringSink
-                      Symbol Type TypeError UnimplementedError UnsupportedError Uri WeakReference]}} 
+           :unresolved-symbol
+           {:exclude
+            [AbstractClassInstantiationError ArgumentError AssertionError
+             BidirectionalIterator BigInt bool Comparable Comparator
+             ConcurrentModificationError CyclicInitializationError DateTime
+             Deprecated double Duration dynamic Error Exception Expando
+             FallThroughError FormatException Function Future IndexError int
+             IntegerDivisionByZeroException Invocation Iterable Iterator
+             LateInitializationError List Map MapEntry Match NoSuchMethodError
+             Null NullThrownError num Object OutOfMemoryError Pattern pragma
+             RangeError Record RegExp RegExpMatch RuneIterator Runes Set Sink
+             StackOverflowError StackTrace StateError Stopwatch Stream String
+             StringBuffer StringSink Symbol Type TypeError UnimplementedError
+             UnsupportedError Uri UriData]}}
  :hooks {:analyze-call {cljd.flutter.alpha/widget hooks.flutter/widget
                         cljd.flutter/build hooks.flutter2/analyze-build
                         cljd.flutter/run hooks.flutter2/widget

--- a/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/config.edn
@@ -14,8 +14,8 @@
              Null NullThrownError num Object OutOfMemoryError Pattern pragma
              RangeError Record RegExp RegExpMatch RuneIterator Runes Set Sink
              StackOverflowError StackTrace StateError Stopwatch Stream String
-             StringBuffer StringSink Symbol Type TypeError UnimplementedError
-             UnsupportedError Uri UriData]}}
+             StringBuffer StringSink super Symbol Type TypeError
+             UnimplementedError UnsupportedError Uri UriData]}}
  :hooks {:analyze-call {cljd.flutter.alpha/widget hooks.flutter/widget
                         cljd.flutter/build hooks.flutter2/analyze-build
                         cljd.flutter/run hooks.flutter2/widget


### PR DESCRIPTION
Updated the list of implicit imports from [ns-prototype](https://github.com/Tensegritics/ClojureDart/blob/8da5840981f17111fbb4442239a12c3605b9297c/clj/src/cljd/compiler.cljc#L279-L349)

Probably resolves https://github.com/clj-kondo/clj-kondo/issues/2229 and https://github.com/clj-kondo/clj-kondo/issues/2231