### PR TITLE
WIP: defprotocol: don't error when options are provided

### DIFF
--- a/clj/src/cljd/compiler.cljc
+++ b/clj/src/cljd/compiler.cljc
@@ -1051,6 +1051,8 @@
   ;; TODO do something with docstrings
   (let [proto (vary-meta proto assoc :tag 'cljd.core/IProtocol)
         [doc-string & methods] (if (string? (first methods)) methods (list* nil methods))
+        [opts methods] (split-with #(not (list? %)) methods)
+        opts (zipmap (take-nth 2 opts) (take-nth 2 (rest opts)))
         method-mapping
         (into {} (map (fn [[m & arglists]]
                         (let [dart-m (munge m {})


### PR DESCRIPTION
Attempting to handle #218 

So far only the compiler error when supplying options is fixed. No attempt has yet been made on actually supporting the actual extension part of it.