### PR TITLE
Exit with error code if compilation unsuccessful

### DIFF
--- a/clj/src/cljd/build.clj
+++ b/clj/src/cljd/build.clj
@@ -316,7 +316,7 @@
                       (println (str "💀 Flutter sub-process exited with " (.exitValue p)))))
                   (finally
                     (some-> p .destroy)))))
-            (System/exit (if compilation-success 0 1))))))))
+            (or compilation-success (System/exit 1))))))))
 
 (defn test-cli [& {:keys [namespaces]}]
   (when (compile-cli :namespaces namespaces)

--- a/clj/src/cljd/build.clj
+++ b/clj/src/cljd/build.clj
@@ -316,7 +316,7 @@
                       (println (str "💀 Flutter sub-process exited with " (.exitValue p)))))
                   (finally
                     (some-> p .destroy)))))
-            compilation-success))))))
+            (System/exit (if compilation-success 0 1))))))))
 
 (defn test-cli [& {:keys [namespaces]}]
   (when (compile-cli :namespaces namespaces)


### PR DESCRIPTION
## Problem

`cljd compile` and `cljd test` exit with code 0 (success) if compilation fails

## Solution

In case compilation was unsuccessful, `System/exit 1`

## Checked

- [x] cljd compile (exits with failure on error)
- [x] cljd test (exits with failure on compile error, runs tests otherwise)
- [x] cljd flutter (nothing changed)