### PR TITLE
[sample.fizzbuzz] Fix null error and work around rendering bug

### DIFF
--- a/samples/fizzbuzz/src/sample/fizzbuzz.cljd
+++ b/samples/fizzbuzz/src/sample/fizzbuzz.cljd
@@ -17,13 +17,14 @@
     (m/Column .mainAxisAlignment m/MainAxisAlignment.center .crossAxisAlignment m/CrossAxisAlignment.stretch)
     .children
     [(f/widget
-       :watch [n s1]
+       :watch [n s1
+               :default 0]
        (m/Text (str n) .textAlign m/TextAlign.center .style text-style))
      (f/widget
-       :watch [n (f/sub [s1 s3] (fn [[n n3]] (if (= n n3) "Fizz" "")))
-               ; default opts to f
-               :sub/opts [{:default 777} {:default 888}]]
+       :watch [n (f/sub [s1 s3] (fn [[n n3]] (if (= n n3) "Fizz" " ")))
+               :default " "]
        (m/Text n .textAlign m/TextAlign.center .style (.apply text-style .color m/Colors.red.shade200)))
      (f/widget
-       :watch [n (f/sub [s1 s5] (fn [[n n5]] (if (= n n5) "Buzz" "")))]
+       :watch [n (f/sub [s1 s5] (fn [[n n5]] (if (= n n5) "Buzz" " ")))
+               :default " "]
        (m/Text n .textAlign m/TextAlign.center .style (.apply text-style .color m/Colors.green.shade200)))]))


### PR DESCRIPTION
- The app displayed a null error message during the first second after startup. Providing :default values to the :watch directives fixed this.
- :sub/opts map deleted because my understanding is that this functionality was removed when cljd.flutter came out of alpha status
- (on Linux with a font size of 64) the number was rendered 1 or 2 pixels higher when "Fizz" and/or "Buzz"  is rendered. Using a single space instead of an empty string as the placeholders fixes this.