### PR TITLE
Fix linter for f/build

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -327,7 +327,7 @@
          (list
           (api/token-node 'fn)
           (if (api/vector-node? argsvec?)
-            argsvec?
-            (api/vector-node []))
+            (api/vector-node (concat [(api/token-node '_ctx)] (:children argsvec?)))
+            (api/vector-node [(api/token-node '_ctx)]))
           widget-node))]
     {:node result}))


### PR DESCRIPTION
## Problem

The current rewrite hook doesn't include the (hidden) context argument.

## Example
```clj
(def foo
  (f/build
   [_]
   m/Container))

(foo ctx 42)
```

### Before
>error: user/foo is called with 2 args but expects 1

### After
Passes lint

## How

Prepend `_ctx` to the rewritten build argsvec