### PR TITLE
CLJ-2649: Fix 3-arg some-fn and every-pred

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -5513,8 +5513,8 @@
     (fn ep3
       ([] true)
       ([x] (boolean (and (p1 x) (p2 x) (p3 x))))
-      ([x y] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y))))
-      ([x y z] (boolean (and (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z))))
+      ([x y] (boolean (and (p1 x) (p1 y) (p2 x) (p2 y) (p3 x) (p3 y))))
+      ([x y z] (boolean (and (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z) (p3 x) (p3 y) (p3 z))))
       ([x y z & args] (boolean (and (ep3 x y z)
                                  (every? #(and (p1 %) (p2 %) (p3 %)) args))))))
    ([p1 p2 p3 & ps]
@@ -5612,8 +5612,8 @@
    (fn sp3
      ([] nil)
      ([x] (or (p1 x) (p2 x) (p3 x)))
-     ([x y] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y)))
-     ([x y z] (or (p1 x) (p2 x) (p3 x) (p1 y) (p2 y) (p3 y) (p1 z) (p2 z) (p3 z)))
+     ([x y] (or (p1 x) (p1 y) (p2 x) (p2 y) (p3 x) (p3 y)))
+     ([x y z] (or (p1 x) (p1 y) (p1 z) (p2 x) (p2 y) (p2 z) (p3 x) (p3 y) (p3 z)))
      ([x y z & args] (or (sp3 x y z)
                        (some #(or (p1 %) (p2 %) (p3 %)) args)))))
   ([p1 p2 p3 & ps]

--- a/clj/test/cljd/test_clojure/core_test_cljd.cljd
+++ b/clj/test/cljd/test_clojure/core_test_cljd.cljd
@@ -209,7 +209,11 @@
   (is (= true (apply distinct? (range 20)))))
 
 (deftest testing-every-pred
-  (is (= true ((every-pred #(< % 10) number?) 1 2 3 4))))
+  (is (= true ((every-pred #(< % 10) number?) 1 2 3 4)))
+  (is (= false ((every-pred some? #(throw (ex-info (str %) {})) some?) 1 nil)))
+  (is (= false ((every-pred some? some? #(throw (ex-info (str %) {}))) 1 nil)))
+  (is (= false ((every-pred some? #(throw (ex-info (str %) {})) some?) 1 1 nil)))
+  (is (= false ((every-pred some? some? #(throw (ex-info (str %) {}))) 1 1 nil))))
 
 (deftest testing-filterv
   (is (= [1 3 5 7 9] (filterv odd? (range 10)))))
@@ -229,6 +233,10 @@
 
 (deftest testing-select-keys
   (is (= {1 1 5 5} (select-keys (into {} (map #(vector % %)) (range 10)) [1 5]))))
+
+(deftest testing-some-fn
+  (is (= true ((some-fn number? odd? #(> % 0)) :a 1)))
+  (is (= true ((some-fn number? odd? #(> % 0)) :a 1 3))))
 
 (deftype Base [x]
   Object


### PR DESCRIPTION
This ports the following patch:

https://github.com/clojure/clojure/commit/42d713929e8f7ecd77efe23384238d29bde62aba