### PR TITLE
Add missing sentinels to partition-by, dedupe, halt-when

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -6449,8 +6449,7 @@
   ([f]
    (fn [rf]
      (let [a #dart []
-           ;; TODO replace "none" by ::none
-           pv (volatile! "none")]
+           pv (volatile! sentinel)]
        (fn
          ([] (rf))
          ([result]
@@ -6465,7 +6464,8 @@
           (let [pval @pv
                 val (f input)]
             (vreset! pv val)
-            (if (or (identical? pval "none") (= val pval))
+            (if (or (identical? pval sentinel)
+                    (= val pval))
               (do
                 (.add a input)
                 result)
@@ -6504,7 +6504,7 @@
   Returns a transducer when no collection is provided."
   ([]
    (fn [rf]
-     (let [pv (volatile! ::none)]
+     (let [pv (volatile! sentinel)]
        (fn
          ([] (rf))
          ([result] (rf result))
@@ -6570,12 +6570,12 @@
      (fn
        ([] (rf))
        ([result]
-        (if (and (map? result) (contains? result ::halt))
-          (::halt result)
+        (if (and (map? result) (contains? result sentinel))
+          (get result sentinel)
           (rf result)))
        ([result input]
         (if (pred input)
-          (reduced {::halt (if retf (retf (rf result) input) input)})
+          (reduced {sentinel (if retf (retf (rf result) input) input)})
           (rf result input)))))))
 
 (defn remove

--- a/clj/test/cljd/test_clojure/core_test.cljd
+++ b/clj/test/cljd/test_clojure/core_test.cljd
@@ -381,22 +381,7 @@
                  ([result input] (rf result input))))]
       (is (= (sequence xf [1 2 3]) [1 2 3 :foo]))))
   (testing "CLJS-2258"
-    (is (= ["1"] (sequence (map str) (eduction [1])))))
-  (testing "sentinels"
-    (is (= [[1] ["none"] [3] ["none"]]
-           (into [] (partition-by identity) [1 "none" 3 "none"])))
-    (is (= [:cljd.core/none]
-           (into [] (dedupe) [:cljd.core/none])
-           (sequence (dedupe) [:cljd.core/none])))
-    (is (= {:cljd.core/halt :should-be-wrapped}
-           (into () (comp (halt-when (fn [_] false))
-                          (fn [rf]
-                            (fn
-                              ([] (rf))
-                              ([result] (rf result))
-                              ([result input]
-                               (reduced {:cljd.core/halt :should-be-wrapped})))))
-                 [1])))))
+    (is (= ["1"] (sequence (map str) (eduction [1]))))))
 
 (deftest test-obj-equiv
   (testing "Object equiv method"

--- a/clj/test/cljd/test_clojure/core_test.cljd
+++ b/clj/test/cljd/test_clojure/core_test.cljd
@@ -381,7 +381,22 @@
                  ([result input] (rf result input))))]
       (is (= (sequence xf [1 2 3]) [1 2 3 :foo]))))
   (testing "CLJS-2258"
-    (is (= ["1"] (sequence (map str) (eduction [1]))))))
+    (is (= ["1"] (sequence (map str) (eduction [1])))))
+  (testing "sentinels"
+    (is (= [[1] ["none"] [3] ["none"]]
+           (into [] (partition-by identity) [1 "none" 3 "none"])))
+    (is (= [:cljd.core/none]
+           (into [] (dedupe) [:cljd.core/none])
+           (sequence (dedupe) [:cljd.core/none])))
+    (is (= {:cljd.core/halt :should-be-wrapped}
+           (into () (comp (halt-when (fn [_] false))
+                          (fn [rf]
+                            (fn
+                              ([] (rf))
+                              ([result] (rf result))
+                              ([result input]
+                               (reduced {:cljd.core/halt :should-be-wrapped})))))
+                 [1])))))
 
 (deftest test-obj-equiv
   (testing "Object equiv method"

--- a/clj/test/cljd/test_clojure/core_test_cljd.cljd
+++ b/clj/test/cljd/test_clojure/core_test_cljd.cljd
@@ -1027,3 +1027,20 @@
         growable-list (List.from x)]
     (List/copyRange growable-list 0 x)
     (is (= (sequence growable-list) []))))
+
+(deftest transducer-sentinels-test
+  (testing "sentinels"
+    (is (= [[1] ["none"] [3] ["none"]]
+           (into [] (partition-by identity) [1 "none" 3 "none"])))
+    (is (= [:cljd.core/none]
+           (into [] (dedupe) [:cljd.core/none])
+           (sequence (dedupe) [:cljd.core/none])))
+    (is (= {:cljd.core/halt :should-be-wrapped}
+           (into () (comp (halt-when (fn [_] false))
+                          (fn [rf]
+                            (fn
+                              ([] (rf))
+                              ([result] (rf result))
+                              ([result input]
+                               (reduced {:cljd.core/halt :should-be-wrapped})))))
+                 [1])))))


### PR DESCRIPTION
Inspired by similar issues found in Clojure:

https://frenchy64.github.io/fully-satisfies/latest/io.github.frenchy64.fully-satisfies.uniform.html