### PR TITLE
`:when` support by clj-kondo

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -200,7 +200,7 @@
   (case (sexpr node-key)
     :get (get-node->let-binding-nodes node-val)
     :bind (bind-node->let-binding-nodes node-val)
-    (:key :keep-alive :spy :padding :color :width :height :visible) [[(token-node '_) node-val]]
+    (:key :keep-alive :spy :padding :color :width :height :when) [[(token-node '_) node-val]]
     (:vsync :context) (vector [(with-meta (token-node (sexpr node-val)) (meta node-val))
                                (token-node 'identity)])
     :let (vector-node->let-binding-nodes node-val)


### PR DESCRIPTION
## What 
Support for `:when` in clj-kondo. Also :visible looks to be not supported so I deleted it.

## Why
This showed warning. (unused-binding)
```clojure
(def pred (atom true))

(f/widget
 :watch [pred? @pred]
 :when pred?
...)
```