### PR TITLE
Provide linter support for user-defined widget directives.

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -207,8 +207,10 @@
     :managed (managed-vector-node->let-binding-nodes node-val)
     :watch (watch-vector-node->let-binding-nodes node-val)
     :bg-watcher [[(token-node '_) (vector-node->bg-watcher-node node-val)]]
-    ;; unsupported keys ignored
-    []))
+    (if (qualified-keyword? (sexpr node-key))
+      [[(token-node '_) (token-node (symbol (sexpr node-key)))]
+       [(token-node '_) node-val]]
+      [])))
 
 (defn nest-body
   [[head & tail]]

--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -207,7 +207,7 @@
     :managed (managed-vector-node->let-binding-nodes node-val)
     :watch (watch-vector-node->let-binding-nodes node-val)
     :bg-watcher [[(token-node '_) (vector-node->bg-watcher-node node-val)]]
-    (if (qualified-keyword? (sexpr node-key))
+    (if (qualified-keyword? (sexpr node-key)) ; not the right place, TODO: reorg the widget function below to be recursive and hopefully both simpler and closer to the actual behavior
       [[(token-node '_) (token-node (symbol (sexpr node-key)))]
        [(token-node '_) node-val]]
       [])))


### PR DESCRIPTION
This provides basic linter support for user-defined directives which includes marking any bindings passed to them as used and ensuring the symbol that the qualified keyword resolves to is defined.

Examples...
```clj
(ns sample.main
  (:require
   ["package:flutter/material.dart" :as m]
   [cljd.flutter :as f]
   [sample.directives :as directives]))

(defn inline-directive [count .child]
  (f/widget
   :bind {:foo count}
   child))

(defn my-widget []
  (f/widget
   :get {navigator m/Navigator}

   ;; warns that this function does not exist
   ::directives/with-something-else {}

   ;; navigator is marked as being used
   ::directives/with-dispatch {:navigator navigator}

   ;; ::inline-directive seems to resolve to clojure.core/inline-directive,
   ;; not sure if I can support that form
   :sample.main/inline-directive 42
   ...))
```

```clj
(ns sample.directives)

(defn with-dispatch [context .child]
  (f/widget
   :bind {:dispatch (fn [action] (prn action))}
   child))
```
