### PR TITLE
Add several convenience functions more closely align with those in clojure.core and cljs.core libraries

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -899,6 +899,11 @@
     (.codeUnitAt ^String x 0)
     (.toInt ^num x)))
 
+(defn ^int long
+  "Coerce to int. Identical to `int`."
+  {:inline (fn [n] `(int ~n))}
+  [x] (int x))
+
 (defn ^String char
   "Coerce to single character string."
   [x]
@@ -2460,6 +2465,13 @@
   ([msg map cause]
    (ExceptionInfo. msg map cause)))
 
+(defn ex-cause
+  "Returns exception cause if ex is an ExceptionInfo.
+   Otherwise returns nil."
+  [ex]
+  (when (instance? ExceptionInfo ex)
+    (.-cause ^ExceptionInfo ex)))
+
 (defn ^bool not
   "Returns true if x is logical false, false otherwise."
   {:inline (fn [x] `^bool (if ~x false true))
@@ -2862,12 +2874,24 @@
   [^num x]
   (.toDouble x))
 
+(defn ^double float
+  "Coerce to double. Identical to `double`."
+  {:inline (fn [x] `(.num:toDouble ~x))
+   :inline-arities #{1}}
+  [^num x] (.toDouble x))
+
 (defn ^bool double?
   "Return true if x is a Double"
   {:inline (fn [x] `(dart/is? ~x dart:core/double))
    :inline-arities #{1}}
   [x]
   (dart/is? x double))
+
+(defn ^bool float?
+  "Return true if x is a Double. Identical to `double?`."
+  {:inline (fn [x] `(dart/is? ~x dart:core/double))
+   :inline-arities #{1}}
+  [x] (dart/is? x double))
 
 ;; bit ops
 (defn ^int bit-not

--- a/clj/src/cljd/edn.cljd
+++ b/clj/src/cljd/edn.cljd
@@ -1,0 +1,18 @@
+;   Copyright (c) Rich Hickey. All rights reserved.
+;   The use and distribution terms for this software are covered by the
+;   Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;   which can be found in the file epl-v10.html at the root of this distribution.
+;   By using this software in any fashion, you are agreeing to be bound by
+;   the terms of this license.
+;   You must not remove this notice, or any other, from this software.
+
+(ns cljd.edn
+  "edn reading"
+  (:require [cljd.reader :as reader]))
+
+(defn read-string
+  "Reads one object from the string s. Returns nil when s is nil or empty.
+
+   Reads data in the edn format (subset of Clojure data):
+   http://edn-format.org"
+  [s] (reader/read-string s))

--- a/clj/src/cljd/math.cljd
+++ b/clj/src/cljd/math.cljd
@@ -164,7 +164,7 @@
   If a is ##NaN => ##NaN
   If a is ##Inf or ##-Inf => a
   If a is zero => zero with sign matching a"
-  [a]
+  [^num a]
   (if (or (NaN? a) (infinite? a))
     a
     (math/pow a CBRT-EXP)))

--- a/clj/src/cljd/test.cljd
+++ b/clj/src/cljd/test.cljd
@@ -280,7 +280,7 @@
          {:type :fail, :message ~msg, :expected '~form,
           :actual (do ~@body)}
          (catch ~klass e#
-           (when-not (re-find ~re (.-message e#))
+           (when-not (re-find ~re (ex-message e#))
              {:type :fail, :message ~msg,
               :expected '~form, :actual e#}))))
     (if (and (sequential? form) (function? env (first form)))

--- a/clj/test/cljd/test_clojure/clojure_walk.cljd
+++ b/clj/test/cljd/test_clojure/clojure_walk.cljd
@@ -51,11 +51,12 @@
 	;;(is (= (type c) (type walked)))
         (if (map? c)
           (is (= (walk #(update-in % [1] inc) #(reduce + (vals %)) c)
-                (reduce + (map (comp inc val) c))))
+                 (reduce + (map (comp inc val) c))))
           (is (= (walk inc #(reduce + %) c)
-                (reduce + (map inc c)))))
-        (when (or (dart/is? c cljd.core/HashRankedWideTreapMap))
-          (is (= (.-cmp c) (.-cmp walked))))))))
+                 (reduce + (map inc c)))))
+        (when (dart/is? c cljd.core/HashRankedWideTreapMap)
+          (is (= (.-cmp ^cljd.core/HashRankedWideTreapMap c)
+                 (.-cmp ^cljd.core/HashRankedWideTreapMap walked))))))))
 
 (deftest walk-mapentry
   "Checks that walk preserves the MapEntry type. See CLJ-2031."

--- a/clj/test/cljd/test_clojure/core_test.cljd
+++ b/clj/test/cljd/test_clojure/core_test.cljd
@@ -314,7 +314,7 @@
 (deftest test-transducers
   (testing "Testing transducers"
     (is (= (sequence (map inc) #dart [1 2 3]) '(2 3 4)))
-    (is (= (apply str (sequence (map #(.toUpperCase %)) "foo")) "FOO"))
+    (is (= (apply str (sequence (map s/upper-case) "foo")) "FOO"))
     (is (== (hash [1 2 3]) (hash (sequence (map inc) (range 3)))))
     (is (= [1 2 3] (sequence (map inc) (range 3))))
     (is (= (sequence (map inc) (range 3)) [1 2 3]))
@@ -592,9 +592,9 @@
     (is (= 5 (js-invoke o "my sum" 2 3)))))
 
 (deftest memfn-test
-  (let [substr (memfn substring start length)]
+  (let [substr (memfn ^String substring start length)]
     (is (= "c" (substr "abcdefg" 2 3))))
-  (let [trim (memfn trim)]
+  (let [trim (memfn ^String trim)]
     (is (= ["abc" "def"] (map trim ["   abc   " "  def   "])))))
 
 ;; =============================================================================

--- a/clj/test/cljd/test_clojure/core_test_cljd.cljd
+++ b/clj/test/cljd/test_clojure/core_test_cljd.cljd
@@ -678,10 +678,10 @@
 (extend-protocol cljd.core/IPrint
   ExtendTypeWorkingOnMultipleNs
   (-print [_ a]
-    (.write ^Sink a "ohoh"))
+    (.write ^StringSink a "ohoh"))
   ExtendTypeWorkingOnMultipleNs2
   (-print [_ a]
-    (.write ^Sink a "ahah")))
+    (.write ^StringSink a "ahah")))
 
 (deftest extend-type-multiple-ns
   (is (= (with-out-str (prn (ExtendTypeWorkingOnMultipleNs)) "ohoh")))
@@ -850,9 +850,10 @@
     (is (identical? x (.-fld obj)))))
 
 (deftest deep-set!
-  (let [obj (MutableBox (MutableBox (MutableBox nil)))]
-    (-> obj .-fld .-fld (.-fld! 1))
-    (is (= 1 (-> obj .-fld .-fld .-fld)))))
+  (letfn [(get-field [^MutableBox box] (.-fld box))]
+    (let [obj (MutableBox (MutableBox (MutableBox nil)))]
+      (-> obj get-field ^MutableBox (get-field) (.-fld! 1))
+      (is (= 1 (-> obj get-field get-field get-field))))))
 
 (deftest testing-set!-prop-not-properly-casted-265
   (let [f (fn [^#/(Map String List) m]

--- a/clj/test/cljd/test_clojure/core_test_cljd.cljd
+++ b/clj/test/cljd/test_clojure/core_test_cljd.cljd
@@ -1154,6 +1154,14 @@
   (is (= nil (ex-message "hello")))
   (is (<= 0 (str/index-of (ex-message (Exception. 'hello)) "hello"))))
 
+(deftest ex-cause-test
+  (is (nil? (ex-cause nil)))
+  (is (nil? (ex-cause :foo)))
+  (is (nil? (ex-cause (ex-info "without cause" {:foo :bar}))))
+  (let [cause (Exception. "the cause")
+        ex    (ex-info "with cause" {:foo :bar} cause)]
+    (is (= cause (ex-cause ex)))))
+
 (comment
   (let [n*2 (set (range 0 1e6 2))
         n*3 (set (range 0 1e6 3))]

--- a/clj/test/cljd/test_clojure/edn_test.cljd
+++ b/clj/test/cljd/test_clojure/edn_test.cljd
@@ -1,0 +1,19 @@
+;; Copyright (c) Rich Hickey. All rights reserved.
+;; The use and distribution terms for this software are covered by the
+;; Eclipse Public License 1.0 (http://opensource.org/licenses/eclipse-1.0.php)
+;; which can be found in the file epl-v10.html at the root of this distribution.
+;; By using this software in any fashion, you are agreeing to be bound by
+;; the terms of this license.
+;; You must not remove this notice, or any other, from this software.
+
+(ns cljd.test-clojure.edn-test
+  (:use [cljd.test :only [deftest is testing]])
+  (:require [cljd.edn :as edn]
+            [cljd.reader :as reader]))
+
+(deftest test-read-string
+  (testing "Mirrors cljs.reader/read-string"
+    (is (= (edn/read-string "(+ 1 2)")
+           (reader/read-string "(+ 1 2)")))
+    (is (= (edn/read-string "{:a #{[1]}}")
+           (reader/read-string "{:a #{[1]}}")))))

--- a/clj/test/cljd/test_clojure/numbers.cljd
+++ b/clj/test/cljd/test_clojure/numbers.cljd
@@ -68,12 +68,12 @@
 (deftest equality-tests
   ;; = only returns true for numbers that are in the same category,
   ;; where category is one of INTEGER, FLOATING, DECIMAL, RATIO.
-  #_(all-pairs-equal #'= [(byte 2) (short 2) (int 2) (long 2)
-                        (bigint 2) (biginteger 2)])
-  #_(all-pairs-equal #'= [(float 2.0) (double 2.0)])
-  (all-pairs-equal #'= [#_(float 0.0) (double 0.0) #_(float -0.0) (double -0.0)])
+  (all-pairs-equal #'= [#_(byte 2) #_(short 2) (int 2) (long 2)
+                        #_(bigint 2) #_(biginteger 2)])
+  (all-pairs-equal #'= [(float 2.0) (double 2.0)])
+  (all-pairs-equal #'= [#(float 0.0) (double 0.0) (float -0.0) (double -0.0)])
   (all-pairs-equal #'= [2.0M 2.00M])
-  #_(all-pairs-equal #'= [(float 1.5) (double 1.5)])
+  (all-pairs-equal #'= [(float 1.5) (double 1.5)])
   (all-pairs-equal #'= [1.50M 1.500M])
   (all-pairs-equal #'= [0.0M 0.00M])
   (all-pairs-equal #'= [(/ 1 2) (/ 2 4)])
@@ -81,22 +81,22 @@
   ;; No BigIntegers or floats in following tests, because hash
   ;; consistency with = for them is out of scope for Clojure
   ;; (CLJ-1036).
-  #_(all-pairs-hash-consistent-with-= [#_(byte 2) #_(short 2) (int 2) #_(long 2)
+  #_(all-pairs-hash-consistent-with-= [#_(byte 2) #_(short 2) (int 2) (long 2)
                                      #_(bigint 2)
                                      (double 2.0) 2.0M 2.00M])
   (all-pairs-hash-consistent-with-= [(/ 3 2) (double 1.5) 1.50M 1.500M])
-  (all-pairs-hash-consistent-with-= [(double -0.0) (double 0.0) -0.0M -0.00M 0.0M 0.00M #_(float -0.0) #_(float 0.0)])
+  (all-pairs-hash-consistent-with-= [(double -0.0) (double 0.0) -0.0M -0.00M 0.0M 0.00M (float -0.0) (float 0.0)])
 
   ;; == tests for numerical equality, returning true even for numbers
   ;; in different categories.
-  (all-pairs-equal #'== [#_(byte 0) #_(short 0) (int 0) #_(long 0)
+  (all-pairs-equal #'== [#_(byte 0) #_(short 0) (int 0) (long 0)
                          #_(bigint 0) #_(biginteger 0)
-                         #_(float -0.0) (double -0.0) -0.0M -0.00M
-                         #_(float 0.0) (double 0.0) 0.0M 0.00M])
-  (all-pairs-equal #'== [#_(byte 2) #_(short 2) (int 2) #_(long 2)
+                         (float -0.0) (double -0.0) -0.0M -0.00M
+                         (float 0.0) (double 0.0) 0.0M 0.00M])
+  (all-pairs-equal #'== [#_(byte 2) #_(short 2) (int 2) (long 2)
                          #_(bigint 2) #_(biginteger 2)
-                         #_(float 2.0) (double 2.0) 2.0M 2.00M])
-  (all-pairs-equal #'== [(/ 3 2) #_(float 1.5) (double 1.5) 1.50M 1.500M]))
+                         (float 2.0) (double 2.0) 2.0M 2.00M])
+  (all-pairs-equal #'== [(/ 3 2) (float 1.5) (double 1.5) 1.50M 1.500M]))
 
 #_(deftest unchecked-cast-num-obj
   (do-template [prim-array cast]
@@ -500,9 +500,9 @@
   (let [nums [#_[(byte 2) (byte 0) (byte -2)]
               #_[(short 3) (short 0) (short -3)]
               [(int 4) (int 0) (int -4)]
-              #_[(long 5) (long 0) (long -5)]
+              [(long 5) (long 0) (long -5)]
               #_[(bigint 6) (bigint 0) (bigint -6)]
-              #_[(float 7) (float 0) (float -7)]
+              [(float 7) (float 0) (float -7)]
               [(double 8) (double 0) (double -8)]
               #_[(bigdec 9) (bigdec 0) (bigdec -9)]
               [2/3 0 -2/3]]

--- a/clj/test/cljd/test_clojure/predicates.cljd
+++ b/clj/test/cljd/test_clojure/predicates.cljd
@@ -184,8 +184,10 @@
   (is (not (NaN? 5)))
   ; Compilation error in Dart
   ;; (is (not (NaN? -5)))
-  (is (thrown? Error (NaN? nil)))
-  (is (thrown? Error (NaN? :xyz)))
+  (let [nil-value nil
+        kw-value  :xyz]
+    (is (thrown? Error (NaN? nil-value)))
+    (is (thrown? Error (NaN? kw-value))))
 
   (is (infinite? ##Inf))
   (is (infinite? ##-Inf))
@@ -194,6 +196,8 @@
   (is (not (infinite? 5)))
   ; Compilation error in Dart
   ;; (is (not (infinite? -5)))
-  (is (thrown? Error (infinite? nil)))
-  (is (thrown? Error (infinite? :xyz)))
+  (let [nil-value nil
+        kw-value  :xyz]
+    (is (thrown? Error (infinite? nil-value)))
+    (is (thrown? Error (infinite? kw-value))))
   )

--- a/clj/test/cljd/test_clojure/predicates.cljd
+++ b/clj/test/cljd/test_clojure/predicates.cljd
@@ -28,9 +28,9 @@
   ;; :byte   (byte 7)
   ;; :short  (short 7)
   :int    (int 7)
-  ;; :long   (long 7)
+  :long   (long 7)
   ;; :bigint (bigint 7)
-  ;; :float  (float 7)
+  :float  (float 7)
   :double (double 7)
   ;; :bigdec (bigdec 7)
 
@@ -76,7 +76,7 @@
   ; boolean?
 
   integer?  [:byte :short :int :long :bigint]
-  ;; float?    [:float :double]
+  float?    [:float :double]
   ;; decimal?  [:bigdec]
   ;; ratio?    [:ratio]
   ;; rational? [:byte :short :int :long :bigint :ratio :bigdec]

--- a/clj/test/cljd/test_reader/reader_test.cljd
+++ b/clj/test/cljd/test_reader/reader_test.cljd
@@ -123,7 +123,7 @@
   (is (= 'abc:def/ghi:jkl.mno (r/read-string "abc:def/ghi:jkl.mno")))
   (is (dart/is?  (r/read-string "alphabet") cljd.core/Symbol))
   (is (= "foo//" (str (r/read-string "foo//"))))
-  (is (true? (-> (r/read-string "##NaN") .-isNaN)))
+  (is (true? (-> (r/read-string "##NaN") NaN?)))
   (is (= double/infinity (r/read-string "##Inf")))
   (is (= double/negativeInfinity (r/read-string "##-Inf")))
   (is (dart/is? (r/read-string "#inst \"2023-01-01T00:00:00.000-00:00\"") DateTime)))
@@ -230,7 +230,7 @@
   #_(is (= (.-pattern #"(?i)abc")
           (.-pattern (r/read-string "#\"(?i)abc\""))))
   (is (= (.-pattern #"\[\]?(\")\\")
-        (.-pattern (r/read-string "#\"\\[\\]?(\\\")\\\\\"")))))
+         (.-pattern ^RegExp (r/read-string "#\"\\[\\]?(\\\")\\\\\"")))))
 
 (deftest read-quote
   (is (= ''foo (r/read-string "'foo"))))

--- a/run-tests
+++ b/run-tests
@@ -24,6 +24,7 @@ clojure -M -m cljd.build compile \
   cljd.test-clojure.core-test \
   cljd.test-clojure.core-test-cljd \
   cljd.test-clojure.data \
+  cljd.test-clojure.edn-test \
   cljd.test-clojure.for \
   cljd.test-clojure.math \
   cljd.test-clojure.numbers \


### PR DESCRIPTION
- Adds functions to `cljd.core`: `long`, `float`, `float?`, `ex-cause`
- Adds single-arity `cljd.edn/read-string`
- Updates `cljd.test/assert-expr` `thrown-with-msg?` assertion to use `ex-message` instead of `.-message`
- Resolves all type warnings that previously showed up in the test output

These changes were made mostly for the convenience they provide in porting other libraries to ClojureDart.
