### PR TITLE
Fix flutter path finding on Windows

### DIFF
--- a/clj/src/cljd/build.clj
+++ b/clj/src/cljd/build.clj
@@ -143,7 +143,7 @@
                  dir (.directory (io/file dir))))
         os-is-windows (.startsWith (System/getProperty "os.name") "Windows")
         path (if os-is-windows
-               (or (-> pb .environment (get "Path")) (-> pb .environment (get "PATH")))
+               (-> pb .environment (select-keys ["Path" "PATH" "path"]) vals first)
                (-> pb .environment (get "PATH")))
         bins (if os-is-windows [(str bin ".exe") (str bin ".bat")] [bin])
         full-bin


### PR DESCRIPTION
The `path` environment variable could be in lower case on Windows.