### PR TITLE
clj-kondo hook: Added support for nil value in watch binding

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -102,7 +102,9 @@
              :value v}
             (conj aggr
                   [k (let [node (api/list-node
-                                 (list (api/token-node 'deref) v))]
+                                 (list (if (nil? (api/sexpr v))
+                                         (api/token-node nil)
+                                         (api/token-node 'deref)) v))]
                        (with-meta node (meta v)))])))
          aggr)))))
 


### PR DESCRIPTION
Refer issue #361 

This fix checks if the value in `:watch` binding is `nil` and if so calls `(api/token-node nil)`, else it fals back to previous behaviour `(api/token-node 'deref)`.