### PR TITLE
Feature documentation more prominently in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,23 @@ How can you help?
 * **Sponsor us** (individual sponsorship is nice but corporate sponshorship is great). You can sponsor any of us or both, it doesn't matter, we split ([:heart: Baptiste](https://github.com/sponsors/dupuchba)  [:heart: Christophe](https://github.com/sponsors/cgrand)).
 * **Contract us** for assistance, training, consulting or dev (can be as mundane as requesting to port a clj/cljs lib to cljd)
 
-# Cheatsheet
+# Documentation
 
-We have a [cheatsheet](doc/ClojureDart%20Cheatsheet.pdf) covering ClojureDart specifics on one side and Flutter programming on the other side.
+To get a working ClojureDart setup quickly, start with either:
+
+- [Flutter QuickStart](doc/flutter-quick-start.md) to build GUIs
+- [Plain Dart QuickStart](doc/quick-start.md) to build CLI apps.
+
+From there, you can consult the following documentation:
+
+- [doc/README.md](doc/README.md) — comprehensive overview of ClojureDart language features
+- [ClojureDart Cheatsheet](doc/ClojureDart%20Cheatsheet.pdf) — printable 2-pager to keep on your desk as a reference
+- [WIP] [ClojureDart Book](doc/BOOK.md) — more in-depth exposition of the what, why, and how of ClojureDart
+- [FAQ](doc/FAQ.md) — answers to Frequently Asked Questions
+- [Differences with Clojure](doc/differences.md) — for if you are already familiar with JVM Clojure
+- [Testing](doc/TESTING.md) — writing and running tests
+
+In the [samples directory](samples/) you find dozens of example projects demonstrating different aspects of ClojureDart and Flutter, see the [samples README](samples/README.md) to know what's what.
 
 # Conj 2025 talk and repl demo
 
@@ -108,11 +122,6 @@ clj -M:cljd flutter
 In most environments this will spawn a desktop app.
 
 More details [there](doc/flutter-quick-start.md)
-
-# Quick starts
-
-- [For Flutter](doc/flutter-quick-start.md) to build GUIs
-- [For Plain Dart](doc/quick-start.md) to build CLI apps.
 
 # Examples
 


### PR DESCRIPTION
I was a bit at a loss after finishing the quickstart, scrolling up and down the README trying to figure out where to go from there. It seemed the only other documentation was the cheatsheet. Turns out there are actually some pretty decent docs, they're just not mentioned anywhere.

This adds links to all the docs that seemed useful for an end user, close to the top of the README.