### PR TITLE
fix: avoid REPL teardown lock poisoning

### DIFF
--- a/clj/src/cljd/build.clj
+++ b/clj/src/cljd/build.clj
@@ -255,14 +255,14 @@
                                                 [cljd.flutter.repl :refer [pick! mount!]]
                                                 [cljd.flutter :as f]
                                                 ["package:flutter/material.dart" :as m]))]
-            (locking *compiler-state
-              (let [p (promise)
-                    _ (swap! *repl-states assoc-in [repltag :ack!] #(deliver p %))
-                    _ (eval-to-repl repltag expr-or-throwable *compiler-state trigger-reload p)
-                    str-or-throwable @p]
-                (if (instance? Throwable str-or-throwable)
-                  (throw str-or-throwable)
-                  (set! compiler/*current-ns* (symbol str-or-throwable)))))
+            (let [p (promise)
+                  _ (locking *compiler-state
+                      (swap! *repl-states assoc-in [repltag :ack!] #(deliver p %))
+                      (eval-to-repl repltag expr-or-throwable *compiler-state trigger-reload p))
+                  str-or-throwable @p]
+              (if (instance? Throwable str-or-throwable)
+                (throw str-or-throwable)
+                (set! compiler/*current-ns* (symbol str-or-throwable))))
             (let [x (try
                       (compiler/read {:eof *in* :read-cond :allow :features #{:cljd}} *in*)
                       (catch Throwable t t))]


### PR DESCRIPTION
## Summary

This fixes a socket REPL teardown race on mobile targets.

If a client disconnects too quickly after an evaluation completes, the REPL session can remain blocked waiting on `@p` while still holding `*compiler-state`. That can block later REPL sessions globally.

## Cause

In `clj/src/cljd/build.clj`, the REPL currently waits for the ack promise inside:

```clojure
(locking *compiler-state ...)
```

That means a stuck or never-delivered ack can leave one session holding the compiler-state lock indefinitely.

## Change

Move the `@p` wait outside `locking *compiler-state`, so the lock is only held during setup / compile / trigger-reload, not during the potentially unbounded wait for the ack.

## Reproduction

### Before
- connect to the mobile REPL
- evaluate a form
- disconnect immediately after the prompt returns
- reconnect
- the later session can hang before evaluation

### After
- same sequence
- the later session reconnects and evaluates normally

## Validation

Validated locally against a real Android device by overriding a sample app to use this local ClojureDart checkout:
- first connection: evaluate `(+ 1 2)` and disconnect immediately
- second connection: reconnect and evaluate `(+ 10 20)`
- result after this patch: second evaluation succeeds

Fixes Tensegritics/ClojureDart#364
