### PR TITLE
Fix flutter clj-kondo hook on native clj-kondo

### DIFF
--- a/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
+++ b/resources/clj-kondo.exports/tensegritics/clojuredart/hooks/flutter2.clj
@@ -229,7 +229,7 @@
             nested-body
             (if (and (api/token-node? maybe-prop)
                      (simple-symbol? (sexpr maybe-prop))
-                     (.startsWith (name (sexpr maybe-prop)) "."))
+                     (str/starts-with? (name (sexpr maybe-prop)) "."))
               (list maybe-prop (nest-body followup))
               (list (api/token-node '.child)
                     (nest-body (list* maybe-prop followup))))]


### PR DESCRIPTION
## Summary

This fixes a clj-kondo hook failure in the Flutter widget hook when running native `clj-kondo`.

The hook currently calls Java's `.startsWith` method on a string value. This works in some Clojure/JVM contexts, but native `clj-kondo` reports:

```text
No matching method startsWith found taking 1 args for class java.lang.String
```

Replacing the direct Java method call with `clojure.string/starts-with?` makes the hook work in native `clj-kondo` while preserving the same behavior.

## Reproduction

Using a minimal ClojureDart project based on the quick start setup:

```clojure
(ns acme.main
  (:require ["package:flutter/material.dart" :as m]
            [cljd.flutter :as f]))

(defn widget []
  (f/widget
   m/RichText
   .text (m/TextSpan .text "ok")))
```

Run clj-kondo with the exported ClojureDart config:

```sh
clj-kondo --lint src/acme/main.cljd \
  --config-dir resources/clj-kondo.exports/tensegritics/clojuredart
```

Before this change, native `clj-kondo` fails with:

```text
src/acme/main.cljd:6:3: error: No matching method startsWith found taking 1 args for class java.lang.String
linting took 141ms, errors: 1, warnings: 0
```

After this change:

```text
linting took 22ms, errors: 0, warnings: 0
```

## Why

The affected branch is reached when `f/widget` receives a widget symbol followed by a property token, for example:

```clojure
(f/widget
 m/RichText
 .text ...)
```

In that case, the hook checks whether the property name starts with `"."`. Using `clojure.string/starts-with?` avoids native reflection/method resolution issues inside clj-kondo hooks.

## Verification

Tested with:

```text
clj-kondo v2026.04.15
```

Also confirmed that the same minimal reproduction fails against the current ClojureDart `main` export and passes with this patch.