### PR TITLE
Fix the error of `parse-long` not being found in Clojure 1.10

### DIFF
--- a/doc/quick-start.md
+++ b/doc/quick-start.md
@@ -23,8 +23,7 @@ mkdir helloworld
 cd helloworld
 cat << EOF > deps.edn
 {:paths ["src"] ; where your cljd files will live
- :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        tensegritics/clojuredart
+ :deps {tensegritics/clojuredart
         {:git/url "git@github.com:tensegritics/ClojureDart.git"
          ; or  "https://github.com/tensegritics/ClojureDart.git"
          :sha "81b5c03a55cf52b21dc0be8ccfa4827b9889f488"}}


### PR DESCRIPTION
The error looks like the following when running `clj -M:cljd init`: Syntax error compiling at (cljd/build.clj:393:51). Unable to resolve symbol: parse-long in this context