### PR TITLE
Add functions: reversible? sorted? special-symbol? parse-uuid

### DIFF
--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -1979,8 +1979,8 @@
   "Returns true if x names a special form"
   [x]
   (contains? '#{. & set! dart/is? dart/await dart/async-barrier dart/run-zoned dart/assert dart/type-like
-                throw new ns try catch finally case* quote do var let* loop* recur if fn* letfn def
-                reify* deftype* defprotocol* defmethod* defmulti* extend-type-protocol*} x))
+                throw new ns try catch finally case* quote do var let* loop* recur if fn* letfn def reify*
+                deftype* defprotocol* defmethod* defmulti* extend-type-protocol* defcontrib* contribute*} x))
 
 (defn symbol
   "Returns a Symbol with the given namespace and name. Arity-1 works

--- a/clj/src/cljd/core.cljd
+++ b/clj/src/cljd/core.cljd
@@ -1659,6 +1659,10 @@
   (-rseq [coll]
     "Returns a seq of the items in coll in reversed order."))
 
+(defn ^bool reversible?
+  "Returns true if coll satisfies? IReversible"
+  [coll] (satisfies? IReversible coll))
+
 (defn rseq
   "Returns, in constant time, a seq of the items in rev (which
   can be a vector or sorted-map), in reverse order. If rev is empty returns nil"
@@ -1678,6 +1682,10 @@
   (-sorted-rseq [coll from to flags]
     "Like -sorted-seq bur returns a sequence in descending order.
      from and to MUST NOT be swapped, they are interpreted as per -sorted-seq."))
+
+(defn ^bool sorted?
+  "Returns true if coll satisfies ISorted"
+  [coll] (satisfies? ISorted coll))
 
 (defn subseq
   "sc must be a sorted collection, test(s) one of <, <=, > or
@@ -1966,6 +1974,13 @@
   "Return true if x is a symbol with a namespace"
   [x]
   (boolean (and (symbol? x) (namespace x) true)))
+
+(defn ^bool special-symbol?
+  "Returns true if x names a special form"
+  [x]
+  (contains? '#{. & set! dart/is? dart/await dart/async-barrier dart/run-zoned dart/assert dart/type-like
+                throw new ns try catch finally case* quote do var let* loop* recur if fn* letfn def
+                reify* deftype* defprotocol* defmethod* defmulti* extend-type-protocol*} x))
 
 (defn symbol
   "Returns a Symbol with the given namespace and name. Arity-1 works
@@ -9457,6 +9472,19 @@ specified.
   (if (string? s)
     (double/tryParse s)
     (throw (ArgumentError (parsing-err s)))))
+
+(def ^:private uuid-regex
+  #"^[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]-[0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F][0-9a-fA-F]$")
+
+(defn parse-uuid
+  "Parse a string representing a UUID and return a UUID instance,
+  or nil if parse fails.
+
+  Grammar: https://docs.oracle.com/javase/8/docs/api/java/util/UUID.html#toString--"
+  [s]
+  (if (string? s)
+    (when (re-matches uuid-regex s) (uuid s))
+    (throw (ArgumentError. (parsing-err s)))))
 
 (defn ^bool? parse-boolean
   {:doc "Parse strings \"true\" or \"false\" and return a boolean, or nil if invalid"

--- a/clj/src/cljd/reader.cljd
+++ b/clj/src/cljd/reader.cljd
@@ -585,15 +585,9 @@
 (defn unquote-splicing? [form]
   (and (seq? form) (= 'cljd.core/unquote-splicing (first form))))
 
-;; TODO: should not be in reader.cljd
-(defn special-form? [form]
-  (contains? '#{. set! dart/is? dart/await dart/async-barrier dart/run-zoned dart/assert dart/type-like
-                throw new ns try case* quote do var let* loop* recur if fn* letfn def reify* deftype*
-                defprotocol* defmethod* defmulti* extend-type-protocol*} form))
-
 (defn- syntax-quote [form]
   (cond
-    (special-form? form) (list 'quote form)
+    (special-symbol? form) (list 'quote form)
     (symbol? form)
     (let [nsform (namespace form)
           nameform (name form)]

--- a/clj/src/cljd/reader.cljd
+++ b/clj/src/cljd/reader.cljd
@@ -585,6 +585,15 @@
 (defn unquote-splicing? [form]
   (and (seq? form) (= 'cljd.core/unquote-splicing (first form))))
 
+;; TODO: should not be in reader.cljd
+(defn special-form?
+  "DEPRECATED. Prefer `cljd.core/special-symbol?`"
+  [form]
+  (println "DEPRECATED, use cljd.core/special-symbol? instead of cljd.reader/special-form?")
+  (contains? '#{. set! dart/is? dart/await dart/async-barrier dart/run-zoned dart/assert dart/type-like
+                throw new ns try case* quote do var let* loop* recur if fn* letfn def reify* deftype*
+                defprotocol* defmethod* defmulti* extend-type-protocol*} form))
+
 (defn- syntax-quote [form]
   (cond
     (special-symbol? form) (list 'quote form)

--- a/clj/test/cljd/test_clojure/parse.cljd
+++ b/clj/test/cljd/test_clojure/parse.cljd
@@ -1,6 +1,6 @@
 (ns cljd.test-clojure.parse
   (:require
-   [clojure.test :refer [deftest is are]]))
+   [clojure.test :refer [deftest is are testing]]))
 
 (def max-int-32 0x7fffffff) ;; 2147483647
 (def max-int-64 0x7fffffffffffffff) ;; 9223372036854775807
@@ -87,6 +87,38 @@
                     (range 100000))]
 
     (is true res)))
+
+(deftest test-parse-uuid
+  (are [x] (uuid? (parse-uuid x))
+    "e2c6efed-dabf-4f55-90bd-58f2c22863be"
+    "1f43838a-80fc-4a8a-be89-306a343ac867")
+
+  (testing "lower and upper case"
+    (let [uuid-lower (parse-uuid "cb048ac2-5e0b-439e-a59f-dfdf11651be0")
+          uuid-upper (parse-uuid "CB048AC2-5E0B-439E-A59F-DFDF11651BE0")]
+      (is (= uuid-lower uuid-upper))
+      (is (uuid? uuid-lower))
+      (is (uuid? uuid-upper))))
+
+  (testing "invalid format"
+    (are [x] (nil? (parse-uuid x))
+      ""
+      "0"
+      "abc123"
+      "000000000-0000-0000-0000-000000000000"   ;; extra leading
+      "00000000-0000-0000-0000-0000000000000")) ;; extra trailing
+
+  (testing "bad input"
+    (are [x] (thrown? ArgumentError (parse-uuid x))
+      nil
+      0
+      0.0
+      :foo
+      'foo
+      []
+      '()
+      {}
+      #{})))
 
 (deftest test-parse-boolean
   (is (identical? true (parse-boolean "true")))

--- a/clj/test/cljd/test_clojure/predicates.cljd
+++ b/clj/test/cljd/test_clojure/predicates.cljd
@@ -143,29 +143,28 @@
 
 (def pred-val-table
   (let [now (DateTime/now)
-        ;; uuid (java.util.UUID/randomUUID)
+        uuid (random-uuid)
         ;; barray (byte-array 0)
         iarray (int-array 0)
         uri (Uri/parse "http://clojure.org")]
-    [
-     [identity   int?  pos-int?  neg-int?  nat-int?  double? boolean? indexed? seqable? ident? #_uuid? #_decimal? inst? uri?  #_bytes?]
-     [0          true  false     false     true      false   false    false    false    false  #_false #_false    false false #_false]
-     [1          true  true      false     true      false   false    false    false    false  #_false #_false    false false #_false]
-     [-1         true  false     true      false     false   false    false    false    false  #_false #_false    false false #_false]
-     [1.0        false false     false     false     true    false    false    false    false  #_false #_false    false false #_false]
-     [true       false false     false     false     false   true     false    false    false  #_false #_false    false false #_false]
-     [[]         false false     false     false     false   false    true     true     false  #_false #_false    false false #_false]
-     [nil        false false     false     false     false   false    true    true     false  #_false #_false    false false #_false]
-     [{}         false false     false     false     false   false    false    true     false  #_false #_false    false false #_false]
-     [:foo       false false     false     false     false   false    false    false    true   #_false #_false    false false #_false]
-     ['foo       false false     false     false     false   false    false    false    true   #_false #_false    false false #_false]
-     #_[0.0M       false false     false     false     false   false    false    false    false  #_false #_true     false false #_false]
-     #_[0N         false false     false     false     false   false    false    false    false  #_false #_false    false false #_false]
-     #_[uuid       false false     false     false     false   false    false    false    false  #_true  #_false    false false #_false]
-     [uri        false false     false     false     false   false    false    false    false  #_false #_false    false true  #_false]
-     [now        false false     false     false     false   false    false    false    false  #_false #_false    true  false #_false]
-     [iarray     false false     false     false     false   false    true    true     false  #_false #_false    false false #_false]
-     #_[barray     false false     false     false     false   false    false    true     false  #_false #_false    false false #_true]]))
+    [[identity   int?  pos-int?  neg-int?  nat-int?  double? boolean? indexed? seqable? reversible? ident? uuid? #_decimal? inst? uri?  #_bytes?]
+     [0          true  false     false     true      false   false    false    false    false       false  false #_false    false false #_false]
+     [1          true  true      false     true      false   false    false    false    false       false  false #_false    false false #_false]
+     [-1         true  false     true      false     false   false    false    false    false       false  false #_false    false false #_false]
+     [1.0        false false     false     false     true    false    false    false    false       false  false #_false    false false #_false]
+     [true       false false     false     false     false   true     false    false    false       false  false #_false    false false #_false]
+     [[]         false false     false     false     false   false    true     true     true        false  false #_false    false false #_false]
+     [nil        false false     false     false     false   false    true     true     false       false  false #_false    false false #_false]
+     [{}         false false     false     false     false   false    false    true     false       false  false #_false    false false #_false]
+     [:foo       false false     false     false     false   false    false    false    false       true   false #_false    false false #_false]
+     ['foo       false false     false     false     false   false    false    false    false       true   false #_false    false false #_false]
+     #_[0.0M       false false     false     false     false   false    false    false    false       false  false #_true     false false #_false]
+     #_[0N         false false     false     false     false   false    false    false    false       false  false #_false    false false #_false]
+     [uuid       false false     false     false     false   false    false    false    false       false  true  #_false    false false #_false]
+     [uri        false false     false     false     false   false    false    false    false       false  false #_false    false true  #_false]
+     [now        false false     false     false     false   false    false    false    false       false  false #_false    true  false #_false]
+     [iarray     false false     false     false     false   false    true     true     false       false   false #_false    false false #_false]
+     #_[barray     false false     false     false     false   false    false    true     false       false  false #_false    false false #_true]]))
 
 (deftest test-preds
   (let [[preds & rows] pred-val-table]
@@ -174,6 +173,24 @@
         (dotimes [i (count row)]
           (is (= ((nth preds i) v) (nth row i))
               (pr-str (list (get-fn-name (nth preds i)) v))))))))
+
+(deftest test-sorted?
+  (are [x] (not (sorted? x))
+    nil
+    0
+    -1.0
+    true
+    :abc
+    ""
+    []
+    #{}
+    {}
+    [1 2 3])
+  (are [x] (sorted? x)
+    (sorted-map)
+    (sorted-map-by compare :foo :bar)
+    (sorted-set)
+    (sorted-set-by compare :foo :bar)))
 
 ;; Special double predicates
 
@@ -201,3 +218,22 @@
     (is (thrown? Error (infinite? nil-value)))
     (is (thrown? Error (infinite? kw-value))))
   )
+
+(deftest test-special-symbol?
+  (are [x] (not (special-symbol? x))
+    nil
+    true
+    false
+    "foo"
+    0
+    0.0
+    :foo
+    'foo/bar
+    'defn
+    'require
+    'letfn*
+    'ns/ns)
+  (are [x] (special-symbol? x)
+    '. '& 'set! 'if 'def 'throw 'new 'ns 'try 'catch 'finally 'do 'var 'letfn 'quote 'recur
+    'dart/is? 'dart/await 'dart/async-barrier 'dart/run-zoned 'dart/assert 'dart/type-like
+    'case* 'let* 'loop* 'fn* 'reify* 'deftype* 'defprotocol* 'defmethod* 'defmulti* 'extend-type-protocol*))

--- a/clj/test/cljd/test_clojure/predicates.cljd
+++ b/clj/test/cljd/test_clojure/predicates.cljd
@@ -236,4 +236,5 @@
   (are [x] (special-symbol? x)
     '. '& 'set! 'if 'def 'throw 'new 'ns 'try 'catch 'finally 'do 'var 'letfn 'quote 'recur
     'dart/is? 'dart/await 'dart/async-barrier 'dart/run-zoned 'dart/assert 'dart/type-like
-    'case* 'let* 'loop* 'fn* 'reify* 'deftype* 'defprotocol* 'defmethod* 'defmulti* 'extend-type-protocol*))
+    'case* 'let* 'loop* 'fn* 'reify* 'deftype* 'defprotocol* 'defmethod* 'defmulti* 'extend-type-protocol*
+    'defcontrib* 'contribute*))

--- a/clj/test/cljd/test_reader/reader_test.cljd
+++ b/clj/test/cljd/test_reader/reader_test.cljd
@@ -534,3 +534,22 @@
 (deftest read-stream
   (let [lines ["(hello " "world)" ":ok"]]
     (is (= '[(hello world) :ok] (-> lines stream r/read-stream .toList await)))))
+
+(deftest test-deprecated-special-form?
+  (testing "Deprecation Warning"
+    (let [out (with-out-str (r/special-form? 'blah))]
+      (is (= "DEPRECATED, use cljd.core/special-symbol? instead of cljd.reader/special-form?\n" out))))
+  
+  (with-out-str
+    (are [x] (not (r/special-form? x))
+      1
+      "dart/is?"
+      :dart/await
+      'prn
+      'dart/blah))
+
+  (with-out-str
+    (are [x] (r/special-form? x)
+      '. 'set! 'dart/is? 'dart/await 'dart/async-barrier 'dart/run-zoned 'dart/assert 'dart/type-like
+      'throw 'new 'ns 'try 'case* 'quote 'do 'var 'let* 'loop* 'recur 'if 'fn* 'letfn 'def 'reify* 'deftype*
+      'defprotocol* 'defmethod* 'defmulti* 'extend-type-protocol*)))


### PR DESCRIPTION
Adds several functions to cljd.core:
- `reversible?`
- `sorted?`
- `special-symbol?`
- `parse-uuid`

### `special-symbol?`

This was moved and renamed from `reader/special-form?` to `core/special-symbol?`, as it exists in JVM and CLJS dialects.

Since this was formerly a public function of `reader.cljd`, this _may_ be breaking if clients depend on it.

The following were _added_ to the set of special symbols:`&`, `catch`, `finally`

### `parse-uuid`

Implementation was inspired by [that in ClojureScript](https://github.com/clojure/clojurescript/blob/master/src/main/cljs/cljs/core.cljs#L12258-L12269). As such, I'm _assuming_ the regex here is correct.