### PR TITLE
Fix cross-namespace defmethod: Unknown symbol on compile

### DIFF
--- a/clj/src/cljd/compiler.cljc
+++ b/clj/src/cljd/compiler.cljc
@@ -915,7 +915,7 @@
             :clj true
             #_#_:cljd/contrib (case kind :defmethod true :defmulti false))
       (let [table# (-> {} transient ; idea (-> {} (^:const (SomeIFnClass)) ...)
-                     ~@(for [cname (keys contributions)]
+                     ~@(for [cname (mapcat vals (vals contributions))]
                          `(~(with-meta (list cname) {:const :required})))
                      persistent!)]
         (cljd.core/-mk-multimethod '~name


### PR DESCRIPTION
## Bug

Any `defmethod` extending a multimethod `defmulti`'d in a **different** namespace fails to compile:

```clojure
;; repro/multi.cljc
(ns repro.multi)
(defmulti kind :type)
(defmethod kind :same-ns [_] "same-ns")

;; repro/ext.cljc
(ns repro.ext
  (:require [repro.multi :as multi]))
(defmethod multi/kind :cross-ns [_] "cross-ns")
```

```
Unknown symbol: multi$SLASH_kind1jgmz0t (no source location)
```

Reproduced on current master (178e4fb) with a fresh (uncached) compile of a plain `:kind :dart` project. Note that a warm `.clojuredart` cache can mask the failure, which may be why this survives day-to-day incremental use.

## Root cause

`expand-method-impl` rebuilds the dispatch table from `(keys contributions)` — the *bare* synthetic method-class names. `emit-contribute*` keys contributions by that bare name and stores the **relocatable** (`$lib:`-qualified, via `relocatable-class-name`) name as the value, keyed by contributing namespace:

```clojure
contributions ; {bare-cname {contributing-ns relocatable-cname}}
```

A bare name only resolves while compiling the namespace that defined the method class. For a same-namespace `defmethod` that happens to be the multimethod's own namespace, so it works; for a cross-namespace one, the multimethod's namespace can't resolve it. The emitted table makes this visible — the same-ns entry is resolved, the cross-ns one isn't:

```clojure
(-> {} transient ((kind1r4nwxi)) ((multi$SLASH_kind1jgmz0t)) persistent!)
```

Protocol extensions already handle this correctly by reading the relocatable names out of the contribution values (`(vals exts)` in the `extensions` expansion).

## Fix

Build the table from the contribution values instead:

```clojure
~@(for [cname (mapcat vals (vals contributions))] ...)
```

After the fix the repro compiles and both dispatches work at runtime (`same-ns` / `cross-ns` both print) — same-namespace methods keep working because relocatable names resolve locally too, same as for protocols.