### PR TITLE
Fix(compiler): guard `rename-lib` aginst injecting bogus test imports

### DIFF
--- a/clj/src/cljd/compiler.cljc
+++ b/clj/src/cljd/compiler.cljc
@@ -4944,7 +4944,8 @@
     (into nses (keep (fn [[ns ns-map]]
                        (when (symbol? ns)
                          (let [{:keys [clj-aliases imports lib contribs]} ns-map
-                               imports (-> imports (dissoc from) (assoc to (imports from)))
+                               imports (let [v (imports from)]
+                                         (cond-> (dissoc imports from) v (assoc to v)))
                                clj-aliases (into {}
                                              (map (fn [[alias lib]]
                                                     [alias (if (= lib from) to lib)]))


### PR DESCRIPTION
Fixes #380, where compiling a test namespace injects a bogus import of the renamed test library into every generated Dart file.

Previously it inserted a nil entry for namespaces that never imported `from` and `dump-ns` emitted an invalid Dart import for that entry.

Tested with a minimal Flutter project containing both a `cljd.test` namespace and a hand-written `test/widget_test.dart`. Before the patch, `clj -M:test:cljd test` fails with:

```text
lib/cljd-out/cljd/core.dart:7:8: Error: Error when reading 'lib/test/cljd-out/.../core-test_test.dart': No such file or directory
```

After the fix, both the ClojureDart test and the Flutter widget test pass, and `dart analyze lib test` reports no bogus-import errors.

The fix is localized to test ns compilation, since `rename-lib` is only called on test nses.